### PR TITLE
Refactor: Split out storage so that is is mostly generic.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ meta
 # dev envierment
 /.helix
 /.vscode
+
+# let this be self generated
+mcmeta/static/forge/forge-legacyinfo.json

--- a/libmcmeta/src/models/forge.rs
+++ b/libmcmeta/src/models/forge.rs
@@ -33,6 +33,7 @@ pub struct ForgeVersionClassifier {
     pub stash: Option<String>,
 }
 
+#[derive(Deserialize, Serialize, Clone, Debug, Validate)]
 pub enum ForgeVersionClassifierExtensions {
     Txt,
     Zip,
@@ -692,7 +693,7 @@ pub struct ForgeOptional {
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, Validate, Merge, Default)]
-pub struct ForgeInstallerProfile {
+pub struct ForgeInstallerProfileV1 {
     pub install: ForgeInstallerProfileInstallSection,
     #[serde(rename = "versionInfo")]
     pub version_info: ForgeVersionFile,
@@ -776,6 +777,13 @@ pub struct ForgeInstallerProfileV2 {
     #[serde(rename = "erverJarPath")]
     #[merge(strategy = merge::option::overwrite_some)]
     server_jar_path: Option<String>,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, Validate)]
+#[serde(untagged)]
+pub enum ForgeInstallerProfile {
+    V1(Box<ForgeInstallerProfileV1>),
+    V2(Box<ForgeInstallerProfileV2>),
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, Validate, Merge, Default)]

--- a/mcmeta/src/app_config.rs
+++ b/mcmeta/src/app_config.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use serde::Deserialize;
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum StorageFormat {
     Json {
@@ -11,7 +11,7 @@ pub enum StorageFormat {
     Database,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct MetadataConfig {
     pub max_parallel_fetch_connections: usize,
     pub static_directory: String,
@@ -46,9 +46,9 @@ impl ServerConfig {
             .set_default("debug_log.path", "./logs")?
             .set_default("debug_log.prefix", "mcmeta.log")?
             .set_default("debug_log.level", "debug")?
-            // optionaly oad config from a file. this is optional though
+            // optionally add config from a file. this is optional though
             .add_source(config::File::from(std::path::Path::new(path)).required(false))
-            // envierment overrides file
+            // environment overrides file
             .add_source(config::Environment::with_prefix("mcmeta").separator("__"))
             .build()?;
 

--- a/mcmeta/src/main.rs
+++ b/mcmeta/src/main.rs
@@ -75,7 +75,7 @@ async fn main() -> Result<()> {
 
     config
         .storage_format
-        .initialize_metadata(&config.metadata)
+        .update_upstream_metadata(&config.metadata)
         .await?;
 
     let raw_mojang_routes = Router::new()

--- a/mcmeta/src/storage/forge.rs
+++ b/mcmeta/src/storage/forge.rs
@@ -579,7 +579,7 @@ impl ForgeDataStorage {
 }
 
 impl UpstreamMetadataUpdater {
-    pub async fn initialize_forge_metadata(&self) -> Result<()> {
+    pub async fn update_upstream_forge(&self) -> Result<()> {
         info!("Checking for Forge metadata");
         self.update_forge_metadata()
             .await
@@ -668,7 +668,7 @@ impl UpstreamMetadataUpdater {
             DerivedForgeIndex::default()
         };
 
-        // update recomendations for local versions, collect local versions
+        // update recommendations for local versions, collect local versions
         let local_index_versions =
             HashSet::<(String, String)>::from_iter(forge_index.versions.iter_mut().map(
                 |(long_version, forge_version)| {

--- a/mcmeta/src/storage/forge.rs
+++ b/mcmeta/src/storage/forge.rs
@@ -1,19 +1,19 @@
+use std::sync::Arc;
+
 use anyhow::{anyhow, Context, Result};
 use futures::{stream, StreamExt};
 use std::collections::{BTreeMap, HashSet};
-use std::path::Path;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 use crate::{
-    app_config::MetadataConfig,
     download,
-    storage::StorageFormat,
-    utils::{filehash, HashAlgo},
+    storage::{StorageFormat, UpstreamMetadataUpdater},
+    utils::{filehash, hash, process_results, process_results_ok, HashAlgo},
 };
 use libmcmeta::models::forge::{
-    DerivedForgeIndex, ForgeEntry, ForgeFile, ForgeInstallerProfile, ForgeInstallerProfileV2,
-    ForgeLegacyInfo, ForgeLegacyInfoList, ForgeMCVersionInfo, ForgeProcessedVersion,
-    ForgeVersionMeta, InstallerInfo,
+    DerivedForgeIndex, ForgeEntry, ForgeFile, ForgeInstallerProfile, ForgeLegacyInfo,
+    ForgeLegacyInfoList, ForgeMCVersionInfo, ForgeMavenMetadata, ForgeMavenPromotions,
+    ForgeProcessedVersion, ForgeVersionMeta, InstallerInfo,
 };
 use libmcmeta::models::mojang::MojangVersion;
 use libmcmeta::models::MetaMcIndexEntry;
@@ -22,301 +22,767 @@ lazy_static! {
     pub static ref BAD_FORGE_VERSIONS: Vec<&'static str> = vec!["1.12.2-14.23.5.2851"];
 }
 
-fn process_results<T>(results: Vec<Result<T>>) -> Result<Vec<T>> {
-    let mut err_flag = false;
-
-    let ok_results: Vec<T> = results
-        .into_iter()
-        .filter_map(|res: Result<T>| match res {
-            Err(err) => {
-                error!("{:?}", err);
-                err_flag = true;
-                None
-            }
-            Ok(ok_res) => Some(ok_res),
-        })
-        .collect();
-    if err_flag {
-        Err(anyhow!("There were errors in the results"))
-    } else {
-        Ok(ok_results)
-    }
+#[derive(Clone)]
+pub struct ForgeDataStorage {
+    storage_format: Arc<StorageFormat>,
 }
 
-fn process_results_ok<T>(results: Vec<Result<T>>) -> Vec<T> {
-    results
-        .into_iter()
-        .filter_map(|res: Result<T>| res.ok())
-        .collect()
-}
+impl ForgeDataStorage {
+    pub fn meta_dir(&self) -> Result<std::path::PathBuf> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                ref meta_directory,
+                generated_directory: _,
+            } => {
+                let metadata_dir = std::path::Path::new(&meta_directory);
+                let forge_meta_dir = metadata_dir.join("forge");
 
-pub async fn initialize_forge_metadata(
-    storage_format: &StorageFormat,
-    metadata_cfg: &MetadataConfig,
-) -> Result<()> {
-    info!("Checking for Forge metadata");
-    match storage_format {
-        StorageFormat::Json {
-            meta_directory,
-            generated_directory: _,
-        } => {
-            update_forge_metadata_json(metadata_cfg, meta_directory)
-                .await
-                .with_context(|| "Failed to update Forge metadata in the json format")?;
-            update_forge_legacy_metadata_json(metadata_cfg, meta_directory)
-                .await
-                .with_context(|| "Failed to update Forge legacy metadata in the json format")
-        }
-        StorageFormat::Database => todo!(),
-    }
-}
-
-async fn update_forge_metadata_json(
-    metadata_cfg: &MetadataConfig,
-    meta_directory: &str,
-) -> Result<()> {
-    let metadata_dir = std::path::Path::new(meta_directory);
-    let forge_meta_dir = metadata_dir.join("forge");
-
-    if !forge_meta_dir.exists() {
-        info!(
-            "Forge metadata directory at {} does not exist, creating it",
-            forge_meta_dir.display()
-        );
-        std::fs::create_dir_all(&forge_meta_dir)?;
-    }
-
-    let maven_metadata = download::forge::load_maven_metadata().await?;
-    let promotions_metadata = download::forge::load_maven_promotions().await?;
-
-    let promoted_key_expression = regex::Regex::new(
-        "(?P<mc>[^-]+)-(?P<promotion>(latest)|(recommended))(-(?P<branch>[a-zA-Z0-9\\.]+))?",
-    )
-    .expect("Promotion regex must compile");
-
-    let mut recommended_set = HashSet::new();
-
-    let mut new_index = DerivedForgeIndex::default();
-
-    // FIXME: does not fully validate that the file has not changed format
-    // NOTE: For some insane reason, the format of the versions here is special. It having a branch at the end means it
-    //           affects that particular branch.
-    //       We don't care about Forge having branches.
-    //       Therefore we only use the short version part for later identification and filter out the branch-specific
-    //           promotions (among other errors).
-    debug!("Processing Forge Promotions");
-
-    for (promo_key, shortversion) in &promotions_metadata.promos {
-        match promoted_key_expression.captures(promo_key) {
-            None => {
-                warn!("Skipping promotion {}, the key did not parse:", promo_key);
-            }
-            Some(captures) => {
-                if captures.name("mc").is_none() {
-                    debug!(
-                        "Skipping promotion {}, because it has no Minecraft version.",
-                        promo_key
+                if !forge_meta_dir.is_dir() {
+                    info!(
+                        "Forge metadata directory at {} does not exist, creating it",
+                        forge_meta_dir.display()
                     );
-                    continue;
+                    std::fs::create_dir_all(&forge_meta_dir)?;
                 }
-                if captures.name("branch").is_some() {
-                    debug!(
-                        "Skipping promotion {}, because it on a branch only.",
-                        promo_key
+                Ok(forge_meta_dir)
+            }
+            StorageFormat::Database => Err(anyhow!("Wrong storage format")),
+        }
+    }
+
+    pub fn manifests_dir(&self) -> Result<std::path::PathBuf> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let forge_file_manifest_path = self.meta_dir()?.join("files_manifests");
+
+                if !forge_file_manifest_path.is_dir() {
+                    info!(
+                        "Forge files manifests directory at {} does not exist, creating it",
+                        forge_file_manifest_path.display()
                     );
-                    continue;
-                } else if let Some(promotion) = captures.name("promotion") {
-                    if promotion.as_str() == "recommended" {
-                        recommended_set.insert(shortversion.clone());
-                        debug!("forge {} added to recommended set", &shortversion);
-                    } else if promotion.as_str() == "latest" {
+                    std::fs::create_dir_all(&forge_file_manifest_path)?;
+                }
+                Ok(forge_file_manifest_path)
+            }
+            StorageFormat::Database => Err(anyhow!("Wrong storage format")),
+        }
+    }
+
+    pub fn load_maven_metadate(&self) -> Result<Option<ForgeMavenMetadata>> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let maven_metadata_file = self.meta_dir()?.join("maven-metadata.json");
+                if maven_metadata_file.is_file() {
+                    let metadata = serde_json::from_str::<ForgeMavenMetadata>(
+                        &std::fs::read_to_string(&maven_metadata_file).with_context(|| {
+                            format!(
+                                "Failure reading from file {}",
+                                &maven_metadata_file.to_string_lossy()
+                            )
+                        })?,
+                    )?;
+                    Ok(Some(metadata))
+                } else {
+                    Ok(None)
+                }
+            }
+            StorageFormat::Database => todo!(),
+        }
+    }
+
+    pub fn store_maven_metadata(&self, metadata: &ForgeMavenMetadata) -> Result<()> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let maven_metadata_file = self.meta_dir()?.join("maven-metadata.json");
+                let maven_metadata_json = serde_json::to_string_pretty(&metadata)?;
+                std::fs::write(&maven_metadata_file, maven_metadata_json).with_context(|| {
+                    format!(
+                        "Failure writing to file {}",
+                        &maven_metadata_file.to_string_lossy()
+                    )
+                })?;
+                Ok(())
+            }
+            StorageFormat::Database => todo!(),
+        }
+    }
+
+    pub fn load_forge_promotions(&self) -> Result<Option<ForgeMavenPromotions>> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let promotions_metadata_file = self.meta_dir()?.join("promotions_slim.json");
+                if promotions_metadata_file.is_file() {
+                    let promotions = serde_json::from_str::<ForgeMavenPromotions>(
+                        &std::fs::read_to_string(&promotions_metadata_file).with_context(|| {
+                            format!(
+                                "Failure reading from file {}",
+                                &promotions_metadata_file.to_string_lossy()
+                            )
+                        })?,
+                    )?;
+                    Ok(Some(promotions))
+                } else {
+                    Ok(None)
+                }
+            }
+            StorageFormat::Database => todo!(),
+        }
+    }
+
+    pub fn store_forge_promotions(&self, promotions: &ForgeMavenPromotions) -> Result<()> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let promotions_metadata_file = self.meta_dir()?.join("promotions_slim.json");
+                let promotions_metadata_json = serde_json::to_string_pretty(&promotions)?;
+                std::fs::write(&promotions_metadata_file, promotions_metadata_json).with_context(
+                    || {
+                        format!(
+                            "Failure writing to file {}",
+                            &promotions_metadata_file.to_string_lossy()
+                        )
+                    },
+                )?;
+
+                Ok(())
+            }
+            StorageFormat::Database => todo!(),
+        }
+    }
+
+    pub fn load_index(&self) -> Result<Option<DerivedForgeIndex>> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let derived_index_file = self.meta_dir()?.join("derived_index.json");
+                if derived_index_file.is_file() {
+                    let index = serde_json::from_str::<DerivedForgeIndex>(
+                        &std::fs::read_to_string(&derived_index_file).with_context(|| {
+                            format!(
+                                "Failure reading from file {}",
+                                &derived_index_file.to_string_lossy()
+                            )
+                        })?,
+                    )?;
+                    Ok(Some(index))
+                } else {
+                    Ok(None)
+                }
+            }
+            StorageFormat::Database => todo!(),
+        }
+    }
+
+    pub fn store_index(&self, index: &DerivedForgeIndex) -> Result<()> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let local_derived_index_file = self.meta_dir()?.join("derived_index.json");
+                let derived_index_json = serde_json::to_string_pretty(&index)?;
+                std::fs::write(&local_derived_index_file, derived_index_json).with_context(
+                    || {
+                        format!(
+                            "Failure writing to file {}",
+                            &local_derived_index_file.to_string_lossy()
+                        )
+                    },
+                )?;
+                Ok(())
+            }
+            StorageFormat::Database => todo!(),
+        }
+    }
+
+    pub fn index_hash(&self) -> Result<Option<String>> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let derived_index_file = self.meta_dir()?.join("derived_index.json");
+                if derived_index_file.is_file() {
+                    let contents =
+                        &std::fs::read_to_string(&derived_index_file).with_context(|| {
+                            format!(
+                                "Failure reading from file {}",
+                                &derived_index_file.to_string_lossy()
+                            )
+                        })?;
+                    let hash_str = hash(contents, HashAlgo::Sha256)?;
+                    Ok(Some(hash_str))
+                } else {
+                    Ok(None)
+                }
+            }
+            StorageFormat::Database => todo!(), // use utils::hash insted of filehash
+        }
+    }
+
+    pub fn load_index_entry(&self) -> Result<Option<MetaMcIndexEntry>> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let last_index_path = self.meta_dir()?.join("derived_index.last_index.json");
+                if last_index_path.is_file() {
+                    Ok(Some(serde_json::from_str::<MetaMcIndexEntry>(
+                        &std::fs::read_to_string(&last_index_path).with_context(|| {
+                            format!("Failure opening {}", &last_index_path.to_string_lossy())
+                        })?,
+                    )?))
+                } else {
+                    Ok(None)
+                }
+            }
+            StorageFormat::Database => todo!(),
+        }
+    }
+
+    pub fn store_index_entry(&self, index_entry: &MetaMcIndexEntry) -> Result<()> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let mut entry = index_entry.clone();
+                let derived_index_file = self.meta_dir()?.join("derived_index.json");
+                let last_index_path = self.meta_dir()?.join("derived_index.last_index.json");
+                entry.path = derived_index_file.to_string_lossy().to_string();
+                let last_index_json = serde_json::to_string_pretty(&entry)?;
+                std::fs::write(&last_index_path, last_index_json).with_context(|| {
+                    format!(
+                        "Failure writing to file {}",
+                        &last_index_path.to_string_lossy()
+                    )
+                })?
+            }
+            StorageFormat::Database => todo!(),
+        }
+        Ok(())
+    }
+
+    pub fn load_files_manifest(&self, version_name: &str) -> Result<Option<ForgeVersionMeta>> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let files_manifest_file =
+                    self.manifests_dir()?.join(format!("{}.json", version_name));
+                if files_manifest_file.is_file() {
+                    let files_manifest = serde_json::from_str::<ForgeVersionMeta>(
+                        &std::fs::read_to_string(&files_manifest_file).with_context(|| {
+                            format!(
+                                "Failure reading file {}",
+                                &files_manifest_file.to_string_lossy()
+                            )
+                        })?,
+                    )?;
+                    Ok(Some(files_manifest))
+                } else {
+                    Ok(None)
+                }
+            }
+            StorageFormat::Database => todo!(),
+        }
+    }
+
+    pub fn store_files_manifest(
+        &self,
+        version_name: &str,
+        manifest: &ForgeVersionMeta,
+    ) -> Result<()> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let files_manifest_file =
+                    self.manifests_dir()?.join(format!("{}.json", version_name));
+
+                let files_metadata_json = serde_json::to_string_pretty(&manifest)?;
+                std::fs::write(&files_manifest_file, files_metadata_json).with_context(|| {
+                    format!(
+                        "Failure writing to file {}",
+                        &files_manifest_file.to_string_lossy()
+                    )
+                })?;
+            }
+            StorageFormat::Database => todo!(),
+        }
+        Ok(())
+    }
+
+    pub fn forge_jars_dir(&self) -> Result<std::path::PathBuf> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let jar_dir = self.meta_dir()?.join("jars");
+                if !jar_dir.is_dir() {
+                    info!(
+                        "Forge jar directory at {} does not exist, creating it",
+                        jar_dir.display()
+                    );
+                    std::fs::create_dir_all(&jar_dir)?;
+                }
+                Ok(jar_dir)
+            }
+            StorageFormat::Database => todo!(),
+        }
+    }
+
+    pub fn installer_manifests_dir(&self) -> Result<std::path::PathBuf> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let installer_manifests_dir = self.meta_dir()?.join("installer_manifests");
+                if !installer_manifests_dir.is_dir() {
+                    info!(
+                        "Forge installer manifests directory at {} does not exist, creating it",
+                        installer_manifests_dir.display()
+                    );
+                    std::fs::create_dir_all(&installer_manifests_dir)?;
+                }
+                Ok(installer_manifests_dir)
+            }
+            StorageFormat::Database => Err(anyhow!("Wrong storage format")),
+        }
+    }
+
+    pub fn load_installer_manifest(
+        &self,
+        version_name: &str,
+    ) -> Result<Option<ForgeInstallerProfile>> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let installer_manifest_file = self
+                    .installer_manifests_dir()?
+                    .join(format!("{}.json", version_name));
+                if installer_manifest_file.is_file() {
+                    let installer_manifest = serde_json::from_str::<ForgeInstallerProfile>(
+                        &std::fs::read_to_string(&installer_manifest_file).with_context(|| {
+                            format!(
+                                "Failure reading file {}",
+                                &installer_manifest_file.to_string_lossy()
+                            )
+                        })?,
+                    )?;
+                    Ok(Some(installer_manifest))
+                } else {
+                    Ok(None)
+                }
+            }
+            StorageFormat::Database => todo!(),
+        }
+    }
+
+    pub fn store_installer_manifest(
+        &self,
+        version_name: &str,
+        manifest: &ForgeInstallerProfile,
+    ) -> Result<()> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let installer_manifest_file = self
+                    .installer_manifests_dir()?
+                    .join(format!("{}.json", version_name));
+
+                let installer_manifest_json = serde_json::to_string_pretty(&manifest)?;
+                std::fs::write(&installer_manifest_file, installer_manifest_json).with_context(
+                    || {
+                        format!(
+                            "Failure writing to file {}",
+                            &installer_manifest_file.to_string_lossy()
+                        )
+                    },
+                )?;
+            }
+            StorageFormat::Database => todo!(),
+        }
+        Ok(())
+    }
+
+    pub fn version_manifests_dir(&self) -> Result<std::path::PathBuf> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let version_manifests_dir = self.meta_dir()?.join("version_manifests");
+                if !version_manifests_dir.is_dir() {
+                    info!(
+                        "Forge verison manifests directory at {} does not exist, creating it",
+                        version_manifests_dir.display()
+                    );
+                    std::fs::create_dir_all(&version_manifests_dir)?;
+                }
+                Ok(version_manifests_dir)
+            }
+            StorageFormat::Database => Err(anyhow!("Wrong storage format")),
+        }
+    }
+
+    pub fn load_mojang_version(&self, version_name: &str) -> Result<Option<MojangVersion>> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let version_manifest_file = self
+                    .version_manifests_dir()?
+                    .join(format!("{}.json", version_name));
+                if version_manifest_file.is_file() {
+                    let version_manifest = serde_json::from_str::<MojangVersion>(
+                        &std::fs::read_to_string(&version_manifest_file).with_context(|| {
+                            format!(
+                                "Failure reading file {}",
+                                &version_manifest_file.to_string_lossy()
+                            )
+                        })?,
+                    )?;
+                    Ok(Some(version_manifest))
+                } else {
+                    Ok(None)
+                }
+            }
+            StorageFormat::Database => todo!(),
+        }
+    }
+
+    pub fn store_mojang_version(&self, version_name: &str, version: &MojangVersion) -> Result<()> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let version_manifest_file = self
+                    .installer_manifests_dir()?
+                    .join(format!("{}.json", version_name));
+
+                let version_manifest_json = serde_json::to_string_pretty(&version)?;
+                std::fs::write(&version_manifest_file, version_manifest_json).with_context(
+                    || {
+                        format!(
+                            "Failure writing to file {}",
+                            &version_manifest_file.to_string_lossy()
+                        )
+                    },
+                )?;
+            }
+            StorageFormat::Database => todo!(),
+        }
+        Ok(())
+    }
+
+    pub fn installer_info_dir(&self) -> Result<std::path::PathBuf> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let installer_info_dir = self.meta_dir()?.join("installer_info");
+                if !installer_info_dir.is_dir() {
+                    info!(
+                        "Forge installer info directory at {} does not exist, creating it",
+                        installer_info_dir.display()
+                    );
+                    std::fs::create_dir_all(&installer_info_dir)?;
+                }
+                Ok(installer_info_dir)
+            }
+            StorageFormat::Database => Err(anyhow!("Wrong storage format")),
+        }
+    }
+
+    pub fn load_installer_info(&self, version_name: &str) -> Result<Option<InstallerInfo>> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let version_manifest_file = self
+                    .version_manifests_dir()?
+                    .join(format!("{}.json", version_name));
+                if version_manifest_file.is_file() {
+                    let version_manifest = serde_json::from_str::<InstallerInfo>(
+                        &std::fs::read_to_string(&version_manifest_file).with_context(|| {
+                            format!(
+                                "Failure reading file {}",
+                                &version_manifest_file.to_string_lossy()
+                            )
+                        })?,
+                    )?;
+                    Ok(Some(version_manifest))
+                } else {
+                    Ok(None)
+                }
+            }
+            StorageFormat::Database => todo!(),
+        }
+    }
+
+    pub fn store_installer_info(
+        &self,
+        version_name: &str,
+        installer_info: &InstallerInfo,
+    ) -> Result<()> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let installer_info_file = self
+                    .installer_manifests_dir()?
+                    .join(format!("{}.json", version_name));
+
+                let installer_info_json = serde_json::to_string_pretty(&installer_info)?;
+                std::fs::write(&installer_info_file, installer_info_json).with_context(|| {
+                    format!(
+                        "Failure writing to file {}",
+                        &installer_info_file.to_string_lossy()
+                    )
+                })?;
+            }
+            StorageFormat::Database => todo!(),
+        }
+        Ok(())
+    }
+}
+
+impl UpstreamMetadataUpdater {
+    pub async fn initialize_forge_metadata(&self) -> Result<()> {
+        info!("Checking for Forge metadata");
+        self.update_forge_metadata()
+            .await
+            .with_context(|| "Failed to update Forge metadata.")?;
+
+        self.update_forge_installer_metadata()
+            .await
+            .with_context(|| "Failed to update Forge legacy metadata.")?;
+        Ok(())
+    }
+
+    pub async fn update_forge_metadata(&self) -> Result<()> {
+        let local_storage = ForgeDataStorage {
+            storage_format: self.storage_format.clone(),
+        };
+
+        let maven_metadata = download::forge::load_maven_metadata().await?;
+        let promotions_metadata = download::forge::load_maven_promotions().await?;
+
+        let promoted_key_expression = regex::Regex::new(
+            "(?P<mc>[^-]+)-(?P<promotion>(latest)|(recommended))(-(?P<branch>[a-zA-Z0-9\\.]+))?",
+        )
+        .expect("Promotion regex must compile");
+
+        let mut recommended_set = HashSet::new();
+
+        let mut new_index = DerivedForgeIndex::default();
+
+        // FIXME: does not fully validate that the file has not changed format
+        // NOTE: For some insane reason, the format of the versions here is special. It having a branch at the end means it
+        //           affects that particular branch.
+        //       We don't care about Forge having branches.
+        //       Therefore we only use the short version part for later identification and filter out the branch-specific
+        //           promotions (among other errors).
+        debug!("Processing Forge Promotions");
+
+        for (promo_key, shortversion) in &promotions_metadata.promos {
+            match promoted_key_expression.captures(promo_key) {
+                None => {
+                    warn!("Skipping promotion {}, the key did not parse:", promo_key);
+                }
+                Some(captures) => {
+                    if captures.name("mc").is_none() {
+                        debug!(
+                            "Skipping promotion {}, because it has no Minecraft version.",
+                            promo_key
+                        );
                         continue;
                     }
-                } else {
-                    warn!("Unknown capture state {:?}", captures);
-                }
-            }
-        }
-    }
-
-    debug!("Processing Forge Versions");
-    let forge_version_pairs = maven_metadata
-        .versions
-        .iter()
-        .flat_map(|(k, v)| v.iter().map(|lv| (k.clone(), lv.clone())))
-        .collect::<Vec<_>>();
-    let tasks = stream::iter(forge_version_pairs)
-        .map(|(mc_version, long_version)| {
-            let version_expression = regex::Regex::new(
-                "^(?P<mc>[0-9a-zA-Z_\\.]+)-(?P<ver>[0-9\\.]+\\.(?P<build>[0-9]+))(-(?P<branch>[a-zA-Z0-9\\.]+))?$"
-            ).expect("Version regex must compile");
-            let forge_dir =  forge_meta_dir.clone();
-            let recommended = recommended_set.clone();
-            tokio::spawn(async move {
-                match version_expression.captures(&long_version) {
-                    None => Err(anyhow!(
-                        "Forge long version {} does not parse!",
-                        long_version
-                    )),
-
-                    Some(captures) => {
-                        if captures.name("mc").is_none() {
-                            Err(anyhow!(
-                                "Forge long version {} not for a minecraft version?",
-                                long_version
-                            ))
-                        } else {
-                            process_forge_version(
-                                &forge_dir,
-                                &recommended,
-                                &mc_version,
-                                &long_version,
-                                captures.name("build").expect("Missing Forge build number").as_str().parse::<i32>()
-                                    .with_context(|| format!("Failure parsing int build number for Forge version `{}`", long_version))?,
-                                captures.name("ver").expect("Missing Forge version").as_str(),
-                                captures.name("branch").map(|b| b.as_str().to_string()),
-                            )
-                            .await
+                    if captures.name("branch").is_some() {
+                        debug!(
+                            "Skipping promotion {}, because it on a branch only.",
+                            promo_key
+                        );
+                        continue;
+                    } else if let Some(promotion) = captures.name("promotion") {
+                        if promotion.as_str() == "recommended" {
+                            recommended_set.insert(shortversion.clone());
+                            debug!("forge {} added to recommended set", &shortversion);
+                        } else if promotion.as_str() == "latest" {
+                            continue;
                         }
+                    } else {
+                        warn!("Unknown capture state {:?}", captures);
                     }
                 }
-            })
-        })
-        .buffer_unordered(metadata_cfg.max_parallel_fetch_connections);
-    let results = tasks
-        .map(|t| match t {
-            Ok(Ok(t)) => Ok(t),
-            Ok(Err(e)) => {
-                debug!("Task had an error: {:?}", e);
-                Err(e)
             }
-            Err(e) => {
-                debug!("Task had a Join error: {:?}", e);
-                Err(e.into())
-            }
-        })
-        .collect::<Vec<_>>()
-        .await;
-    let forge_versions = process_results(results)?;
-
-    for forge_version in forge_versions {
-        let mc_version = forge_version.mc_version.clone();
-        let long_version = forge_version.long_version.clone();
-        new_index
-            .versions
-            .insert(forge_version.long_version.clone(), forge_version.clone());
-        if !new_index.by_mc_version.contains_key(&mc_version) {
-            new_index
-                .by_mc_version
-                .insert(mc_version.clone(), ForgeMCVersionInfo::default());
         }
-        new_index
-            .by_mc_version
-            .get_mut(&mc_version)
-            .unwrap_or_else(|| panic!("Missing forge info for minecraft version {}", &mc_version))
+
+        debug!("Processing Forge Versions");
+        let forge_version_pairs = maven_metadata
             .versions
-            .push(long_version.clone());
-        // NOTE: we add this later after the fact. The forge promotions file lies about these.
-        // if let Some(true) = forge_version.latest {
-        //     new_index.by_mc_version[&mc_version].latest = Some(long_version.clone());
-        // }
-        if let Some(true) = forge_version.recommended {
+            .iter()
+            .flat_map(|(k, v)| v.iter().map(|lv| (k.clone(), lv.clone())))
+            .collect::<Vec<_>>();
+        let tasks = stream::iter(forge_version_pairs)
+            .map(|(mc_version, long_version)| {
+                let version_expression = regex::Regex::new(
+                    "^(?P<mc>[0-9a-zA-Z_\\.]+)-(?P<ver>[0-9\\.]+\\.(?P<build>[0-9]+))(-(?P<branch>[a-zA-Z0-9\\.]+))?$"
+                ).expect("Version regex must compile");
+                let ls = local_storage.clone();
+                let recommended = recommended_set.clone();
+                tokio::spawn(async move {
+                    match version_expression.captures(&long_version) {
+                        None => Err(anyhow!(
+                            "Forge long version {} does not parse!",
+                            long_version
+                        )),
+
+                        Some(captures) => {
+                            if captures.name("mc").is_none() {
+                                Err(anyhow!(
+                                    "Forge long version {} not for a minecraft version?",
+                                    long_version
+                                ))
+                            } else {
+                                process_forge_version(
+                                    &ls,
+                                    &recommended,
+                                    &mc_version,
+                                    &long_version,
+                                    captures.name("build").expect("Missing Forge build number").as_str().parse::<i32>()
+                                        .with_context(|| format!("Failure parsing int build number for Forge version `{}`", long_version))?,
+                                    captures.name("ver").expect("Missing Forge version").as_str(),
+                                    captures.name("branch").map(|b| b.as_str().to_string()),
+                                )
+                                .await
+                            }
+                        }
+                    }
+                })
+            })
+            .buffer_unordered(self.metadata_cfg.max_parallel_fetch_connections);
+        let results = tasks
+            .map(|t| match t {
+                Ok(Ok(t)) => Ok(t),
+                Ok(Err(e)) => {
+                    debug!("Task had an error: {:?}", e);
+                    Err(e)
+                }
+                Err(e) => {
+                    debug!("Task had a Join error: {:?}", e);
+                    Err(e.into())
+                }
+            })
+            .collect::<Vec<_>>()
+            .await;
+        let forge_versions = process_results(results)?;
+
+        for forge_version in forge_versions {
+            let mc_version = forge_version.mc_version.clone();
+            let long_version = forge_version.long_version.clone();
+            new_index
+                .versions
+                .insert(forge_version.long_version.clone(), forge_version.clone());
+            if !new_index.by_mc_version.contains_key(&mc_version) {
+                new_index
+                    .by_mc_version
+                    .insert(mc_version.clone(), ForgeMCVersionInfo::default());
+            }
             new_index
                 .by_mc_version
                 .get_mut(&mc_version)
                 .unwrap_or_else(|| {
                     panic!("Missing forge info for minecraft version {}", &mc_version)
                 })
-                .recommended = Some(long_version.clone());
+                .versions
+                .push(long_version.clone());
+            // NOTE: we add this later after the fact. The forge promotions file lies about these.
+            // if let Some(true) = forge_version.latest {
+            //     new_index.by_mc_version[&mc_version].latest = Some(long_version.clone());
+            // }
+            if let Some(true) = forge_version.recommended {
+                new_index
+                    .by_mc_version
+                    .get_mut(&mc_version)
+                    .unwrap_or_else(|| {
+                        panic!("Missing forge info for minecraft version {}", &mc_version)
+                    })
+                    .recommended = Some(long_version.clone());
+            }
         }
+
+        debug!("Post-processing forge promotions and adding missing 'latest'");
+
+        for (mc_version, info) in &mut new_index.by_mc_version {
+            let latest_version = info.versions.last().unwrap_or_else(|| {
+                panic!("No forge versions for minecraft version {}", mc_version)
+            });
+            info.latest = Some(latest_version.to_string());
+            info!("Added {} as latest for {}", latest_version, mc_version)
+        }
+
+        debug!("Dumping forge index files");
+        local_storage.store_maven_metadata(&maven_metadata)?;
+        local_storage.store_forge_promotions(&promotions_metadata)?;
+        local_storage.store_index(&new_index)?;
+
+        Ok(())
     }
 
-    debug!("Post-processing forge promotions and adding missing 'latest'");
+    pub async fn update_forge_installer_metadata(&self) -> Result<()> {
+        let local_storage = ForgeDataStorage {
+            storage_format: self.storage_format.clone(),
+        };
 
-    for (mc_version, info) in &mut new_index.by_mc_version {
-        let latest_version = info
-            .versions
-            .last()
-            .unwrap_or_else(|| panic!("No forge versions for minecraft version {}", mc_version));
-        info.latest = Some(latest_version.to_string());
-        info!("Added {} as latest for {}", latest_version, mc_version)
-    }
+        let static_dir = std::path::Path::new(&self.metadata_cfg.static_directory);
+        let legacy_info_path = static_dir.join("forge").join("forge-legacyinfo.json");
+        let aquire_legacy_info = !legacy_info_path.is_file();
 
-    debug!("Dumping forge index files");
+        let mut legacy_info_list = ForgeLegacyInfoList::default();
 
-    {
-        let local_maven_metadata_file = forge_meta_dir.join("maven-metadata.json");
-        let maven_metadata_json = serde_json::to_string_pretty(&maven_metadata)?;
-        std::fs::write(&local_maven_metadata_file, maven_metadata_json).with_context(|| {
-            format!(
-                "Failure writing to file {}",
-                &local_maven_metadata_file.to_string_lossy()
-            )
-        })?;
-    }
+        debug!("Grabbing forge installers and dumping installer profiles...");
 
-    {
-        let local_promotions_metadata_file = forge_meta_dir.join("promotions_slim.json");
-        let promotions_metadata_json = serde_json::to_string_pretty(&promotions_metadata)?;
-        std::fs::write(&local_promotions_metadata_file, promotions_metadata_json).with_context(
-            || {
-                format!(
-                    "Failure writing to file {}",
-                    &local_promotions_metadata_file.to_string_lossy()
-                )
-            },
-        )?;
-    }
+        let derived_index = local_storage
+            .load_index()?
+            .ok_or(anyhow!("local forge index missing"))?;
 
-    {
-        let local_derived_index_file = forge_meta_dir.join("derived_index.json");
-        let derived_index_json = serde_json::to_string_pretty(&new_index)?;
-        std::fs::write(&local_derived_index_file, derived_index_json).with_context(|| {
-            format!(
-                "Failure writing to file {}",
-                &local_derived_index_file.to_string_lossy()
-            )
-        })?;
-    }
+        let derived_index_hash = local_storage
+            .index_hash()?
+            .ok_or(anyhow!("local forge index missing"))?;
 
-    Ok(())
-}
-
-async fn update_forge_legacy_metadata_json(
-    metadata_cfg: &MetadataConfig,
-    meta_directory: &str,
-) -> Result<()> {
-    let metadata_dir = std::path::Path::new(meta_directory);
-    let forge_meta_dir = metadata_dir.join("forge");
-    let static_dir = std::path::Path::new(&metadata_cfg.static_directory);
-    let legacy_info_path = static_dir.join("forge").join("forge-legacyinfo.json");
-
-    let mut legacy_info_list = ForgeLegacyInfoList::default();
-
-    debug!("Grabbing forge installers and dumping installer profiles...");
-
-    let derived_index_file = forge_meta_dir.join("derived_index.json");
-    let derived_index = serde_json::from_str::<DerivedForgeIndex>(
-        &std::fs::read_to_string(&derived_index_file).with_context(|| {
-            format!("Failure opening {}", &derived_index_file.to_string_lossy())
-        })?,
-    )
-    .with_context(|| {
-        format!(
-            "Failure reading json from {}",
-            &derived_index_file.to_string_lossy()
-        )
-    })?;
-
-    let derived_index_hash = filehash(&derived_index_file, HashAlgo::Sha256)?;
-
-    let last_index_path = forge_meta_dir.join("derived_index.last_index.json");
-    if last_index_path.is_file() {
-        if let Ok(last_index) = serde_json::from_str::<MetaMcIndexEntry>(
-            &std::fs::read_to_string(&last_index_path).with_context(|| {
-                format!("Failure opening {}", &last_index_path.to_string_lossy())
-            })?,
-        ) {
+        if let Some(last_index) = local_storage.load_index_entry()? {
             // check if we even need to regenerate
             if last_index.hash == derived_index_hash {
                 info!("Forge index up to date. Not regenerating.");
@@ -325,85 +791,79 @@ async fn update_forge_legacy_metadata_json(
                 info!("Forge index hash did not match, regenerating...")
             }
         }
-    }
 
-    // get the installer jars - if needed - and get the installer profiles out of them
-    let tasks = stream::iter(derived_index.versions)
-        .filter_map(|(key, entry)| async move {
-            info!("Updating Forge {}", &key);
-            let version = ForgeProcessedVersion::new(&entry);
+        // get the installer jars - if needed - and get the installer profiles out of them
+        let tasks = stream::iter(derived_index.versions)
+            .filter_map(|(key, entry)| async move {
+                info!("Updating Forge {}", &key);
+                let version = ForgeProcessedVersion::new(&entry);
 
-            if version.url().is_none() {
-                debug!("Skipping forge build {} with no valid files", &entry.build);
-                return None;
-            }
+                if version.url().is_none() {
+                    debug!("Skipping forge build {} with no valid files", &entry.build);
+                    return None;
+                }
 
-            if BAD_FORGE_VERSIONS.contains(&version.long_version.as_str()) {
-                debug!("Skipping bad forge version {}", &version.long_version);
-                return None;
-            }
+                if BAD_FORGE_VERSIONS.contains(&version.long_version.as_str()) {
+                    debug!("Skipping bad forge version {}", &version.long_version);
+                    return None;
+                }
 
-            Some(version)
-        })
-        .map(|version| {
-            let fm_dir = forge_meta_dir.clone();
-            let li_path = legacy_info_path.clone();
-            tokio::spawn(async move {
-                process_legecy_forge_version(&version, fm_dir.as_path(), li_path.as_path()).await
+                Some(version)
             })
-        })
-        .buffer_unordered(metadata_cfg.max_parallel_fetch_connections);
-    let results = tasks
-        .map(|t| match t {
-            Ok(Ok(t)) => Ok(t),
-            Ok(Err(e)) => {
-                debug!("Task had an error: {:?}", e);
-                Err(e)
-            }
-            Err(e) => {
-                debug!("Task had a Join error: {:?}", e);
-                Err(e.into())
-            }
-        })
-        .collect::<Vec<_>>()
-        .await;
+            .map(|version| {
+                let ls = local_storage.clone();
+                tokio::spawn(async move {
+                    process_forge_installer(&ls, &version, aquire_legacy_info).await
+                })
+            })
+            .buffer_unordered(self.metadata_cfg.max_parallel_fetch_connections);
+        let results = tasks
+            .map(|t| match t {
+                Ok(Ok(t)) => Ok(t),
+                Ok(Err(e)) => {
+                    debug!("Task had an error: {:?}", e);
+                    Err(e)
+                }
+                Err(e) => {
+                    debug!("Task had a Join error: {:?}", e);
+                    Err(e.into())
+                }
+            })
+            .collect::<Vec<_>>()
+            .await;
 
-    let legacy_version_infos = process_results_ok(results);
+        let legacy_version_infos = process_results_ok(results);
 
-    for (long_version, version_info) in legacy_version_infos.into_iter().flatten() {
-        legacy_info_list.number.insert(long_version, version_info);
+        for (long_version, version_info) in legacy_version_infos.into_iter().flatten() {
+            legacy_info_list.number.insert(long_version, version_info);
+        }
+
+        // only write legacy info if it's missing
+        if !legacy_info_path.is_file() {
+            let legacy_info_json = serde_json::to_string_pretty(&legacy_info_list)?;
+            std::fs::write(&legacy_info_path, legacy_info_json).with_context(|| {
+                format!(
+                    "Failure writing to file {}",
+                    &legacy_info_path.to_string_lossy()
+                )
+            })?;
+        }
+
+        // update our index
+        let last_index = MetaMcIndexEntry {
+            update_time: time::OffsetDateTime::now_utc(),
+            path: "".to_owned(),
+            hash: derived_index_hash,
+        };
+
+        local_storage.store_index_entry(&last_index)?;
+
+        Ok(())
     }
-
-    // only write legacy info if it's missing
-    if !legacy_info_path.is_file() {
-        let legacy_info_json = serde_json::to_string_pretty(&legacy_info_list)?;
-        std::fs::write(&legacy_info_path, legacy_info_json).with_context(|| {
-            format!(
-                "Failure writing to file {}",
-                &legacy_info_path.to_string_lossy()
-            )
-        })?;
-    }
-
-    // update our index
-    let last_index = MetaMcIndexEntry {
-        update_time: time::OffsetDateTime::now_utc(),
-        path: derived_index_file.to_str().unwrap().to_string(),
-        hash: derived_index_hash,
-    };
-    let last_index_json = serde_json::to_string_pretty(&last_index)?;
-    std::fs::write(&last_index_path, last_index_json).with_context(|| {
-        format!(
-            "Failure writing to file {}",
-            &last_index_path.to_string_lossy()
-        )
-    })?;
-
-    Ok(())
 }
 
 async fn process_forge_version(
-    forge_meta_dir: &Path,
+    local_storage: &ForgeDataStorage,
     recommended_set: &HashSet<String>,
     mc_version: &str,
     long_version: &str,
@@ -411,7 +871,7 @@ async fn process_forge_version(
     version: &str,
     branch: Option<String>,
 ) -> Result<ForgeEntry> {
-    let files = get_single_forge_files_manifest(forge_meta_dir, long_version).await?;
+    let files = get_single_forge_files_manifest(&local_storage, long_version).await?;
 
     let is_recommended = recommended_set.contains(version);
 
@@ -430,36 +890,25 @@ async fn process_forge_version(
 }
 
 async fn get_single_forge_files_manifest(
-    forge_meta_dir: &Path,
+    local_storage: &ForgeDataStorage,
     long_version: &str,
 ) -> Result<BTreeMap<String, ForgeFile>> {
-    info!("Getting Forge manifest for {long_version}");
-
-    let forge_file_manifest_path = forge_meta_dir.join("files_manifests");
-
-    if !forge_file_manifest_path.exists() {
-        info!(
-            "Forge files manifests directory at {} does not exist, creating it",
-            forge_file_manifest_path.display()
-        );
-        std::fs::create_dir_all(&forge_file_manifest_path)?;
-    }
-
-    let files_manifest_file = forge_file_manifest_path.join(format!("{}.json", long_version));
-
-    let mut from_file = false;
-
-    let files_metadata = if files_manifest_file.is_file() {
-        from_file = true;
-        serde_json::from_str::<ForgeVersionMeta>(&std::fs::read_to_string(&files_manifest_file)?)?
+    let files_manifest = local_storage.load_files_manifest(&long_version)?;
+    let files_metadata = if let Some(files_manifest) = files_manifest {
+        info!("Forge manifest for {long_version} stored localy");
+        files_manifest
     } else {
+        info!("Getting Forge manifest for {long_version}");
+
         let file_url = format!(
             "https://files.minecraftforge.net/net/minecraftforge/forge/{}/meta.json",
             &long_version
         );
-        download::forge::load_single_forge_files_manifest(&file_url)
+        let remote_manifest = download::forge::load_single_forge_files_manifest(&file_url)
             .await
-            .with_context(|| format!("Failure downloading {}", &file_url))?
+            .with_context(|| format!("Failure downloading {}", &file_url))?;
+        local_storage.store_files_manifest(&long_version, &remote_manifest)?;
+        remote_manifest
     };
 
     let mut ret_map: BTreeMap<String, ForgeFile> = BTreeMap::new();
@@ -507,55 +956,23 @@ async fn get_single_forge_files_manifest(
             }
         }
     }
-
-    if !from_file {
-        let files_metadata_json = serde_json::to_string_pretty(&files_metadata)?;
-        std::fs::write(&files_manifest_file, files_metadata_json).with_context(|| {
-            format!(
-                "Failure writing to file {}",
-                &files_manifest_file.to_string_lossy()
-            )
-        })?;
-    }
-
     Ok(ret_map)
 }
 
-async fn process_legecy_forge_version(
+async fn process_forge_installer(
+    local_storage: &ForgeDataStorage,
     version: &ForgeProcessedVersion,
-    forge_meta_dir: &Path,
-    legacy_info_path: &Path,
+    aquire_legacy_info: bool,
 ) -> Result<Option<(String, ForgeLegacyInfo)>> {
-    let jar_path = forge_meta_dir
-        .join("jars")
+    let jar_path = local_storage
+        .forge_jars_dir()?
         .join(&version.filename().expect("Missing forge filename"));
 
-    let version_json_name = format!("{}.json", &version.long_version);
-
-    let installer_manifests_dir = forge_meta_dir.join("installer_manifests");
-    if !installer_manifests_dir.exists() {
-        std::fs::create_dir_all(&installer_manifests_dir)
-            .with_context(|| "Failed to create forge `installer_manifests` directory")?;
-    }
-
-    let version_manifests_dir = forge_meta_dir.join("version_manifests");
-    if !version_manifests_dir.exists() {
-        std::fs::create_dir_all(&version_manifests_dir)
-            .with_context(|| "Failed to create forge `version_manifests` directory")?;
-    }
-
-    let installer_info_dir = forge_meta_dir.join("installer_info");
-    if !installer_info_dir.exists() {
-        std::fs::create_dir_all(&installer_info_dir)
-            .with_context(|| "Failed to create forge `installer_info` directory")?;
-    }
-
     if version.uses_installer() {
-        let installer_info_path = installer_info_dir.join(&version_json_name);
-        let profile_path = installer_manifests_dir.join(&version_json_name);
-        let version_file_path = version_manifests_dir.join(&version_json_name);
+        let installer_info = local_storage.load_installer_info(&version.long_version)?;
+        let profile = local_storage.load_installer_manifest(&version.long_version)?;
 
-        let installer_refresh_required = !profile_path.is_file() || !installer_info_path.is_file();
+        let installer_refresh_required = profile.is_none() || installer_info.is_none();
 
         if installer_refresh_required {
             // grab the installer if it's not there
@@ -568,7 +985,7 @@ async fn process_legecy_forge_version(
         }
 
         debug!("Processing forge jar from {}", &version.url().unwrap());
-        if !profile_path.is_file() {
+        if profile.is_none() {
             use std::io::Read;
 
             let mut jar = zip::ZipArchive::new(
@@ -603,13 +1020,7 @@ async fn process_legecy_forge_version(
                             )
                         })?;
 
-                    let version_file_json = serde_json::to_string_pretty(&mojang_version)?;
-                    std::fs::write(&version_file_path, version_file_json).with_context(|| {
-                        format!(
-                            "Failure writing to file {}",
-                            &version_file_path.to_string_lossy()
-                        )
-                    })?;
+                    local_storage.store_mojang_version(&version.long_version, &mojang_version)?;
                 }
             }
 
@@ -632,31 +1043,13 @@ async fn process_legecy_forge_version(
                         )
                     })?;
 
-                let forge_profile_json: Result<String> = {
-                    let forge_profile =
-                        serde_json::from_str::<ForgeInstallerProfile>(&install_profile_data);
-                    if let Ok(profile) = forge_profile {
-                        Ok(serde_json::to_string_pretty(&profile)?)
-                    } else {
-                        let forge_profile_v2 =
-                            serde_json::from_str::<ForgeInstallerProfileV2>(&install_profile_data);
-                        if let Ok(profile) = forge_profile_v2 {
-                            Ok(serde_json::to_string_pretty(&profile)?)
-                        } else {
-                            Err(forge_profile_v2.unwrap_err().into())
-                        }
-                    }
-                };
-
-                if let Ok(forge_profile_json) = forge_profile_json {
-                    std::fs::write(&profile_path, forge_profile_json).with_context(|| {
-                        format!(
-                            "Failure writing to file {}",
-                            &profile_path.to_string_lossy()
-                        )
-                    })?;
+                let forge_profile =
+                    serde_json::from_str::<ForgeInstallerProfile>(&install_profile_data);
+                if let Ok(forge_profile) = forge_profile {
+                    local_storage
+                        .store_installer_manifest(&version.long_version, &forge_profile)?;
                 } else if version.is_supported() {
-                    return Err(forge_profile_json.unwrap_err()).with_context(|| {
+                    return Err(forge_profile.unwrap_err()).with_context(|| {
                         format!(
                             "Failure reading json from 'install_profile.json' in {}",
                             &jar_path.to_string_lossy()
@@ -671,20 +1064,14 @@ async fn process_legecy_forge_version(
             }
         }
 
-        if !installer_info_path.is_file() {
+        if installer_info.is_none() {
             let installer_info = InstallerInfo {
                 sha1hash: Some(filehash(&jar_path, HashAlgo::Sha1)?),
                 sha256hash: Some(filehash(&jar_path, HashAlgo::Sha256)?),
                 size: Some(jar_path.metadata()?.len()),
             };
 
-            let installer_info_json = serde_json::to_string_pretty(&installer_info)?;
-            std::fs::write(&installer_info_path, installer_info_json).with_context(|| {
-                format!(
-                    "Failure writing to file {}",
-                    &installer_info_path.to_string_lossy()
-                )
-            })?;
+            local_storage.store_installer_info(&version.long_version, &installer_info)?;
         }
         Ok(None)
     } else {
@@ -696,7 +1083,7 @@ async fn process_legecy_forge_version(
         }
 
         // only gather legacy info if it's missing
-        if !legacy_info_path.is_file() {
+        if aquire_legacy_info {
             if !jar_path.is_file() {
                 debug!("Downloading forge jar from {}", &version.url().unwrap());
                 download::download_binary_file(&jar_path, &version.url().unwrap())

--- a/mcmeta/src/storage/forge.rs
+++ b/mcmeta/src/storage/forge.rs
@@ -767,7 +767,20 @@ impl UpstreamMetadataUpdater {
         };
 
         let static_dir = std::path::Path::new(&self.metadata_cfg.static_directory);
-        let legacy_info_path = static_dir.join("forge").join("forge-legacyinfo.json");
+        let forge_static_dir = static_dir.join("forge");
+        if !forge_static_dir.is_dir() {
+            info!(
+                "Forge static metadata directory at {} does not exist, creating it",
+                &forge_static_dir.to_string_lossy()
+            );
+            std::fs::create_dir_all(&forge_static_dir).with_context(|| {
+                format!(
+                    "Failed to create forge static dir {}",
+                    &forge_static_dir.to_string_lossy()
+                )
+            })?;
+        }
+        let legacy_info_path = forge_static_dir.join("forge-legacyinfo.json");
         let aquire_legacy_info = !legacy_info_path.is_file();
 
         let mut legacy_info_list = ForgeLegacyInfoList::default();

--- a/mcmeta/src/storage/forge.rs
+++ b/mcmeta/src/storage/forge.rs
@@ -662,7 +662,7 @@ impl UpstreamMetadataUpdater {
         let mut forge_index = if let Some(local_forge_index) = local_forge_index {
             DerivedForgeIndex {
                 versions: local_forge_index.versions.clone(),
-                by_mc_version: local_forge_index.by_mc_version.clone(),
+                by_mc_version: local_forge_index.by_mc_version,
             }
         } else {
             DerivedForgeIndex::default()
@@ -936,7 +936,7 @@ async fn process_forge_version(
     version: &str,
     branch: Option<String>,
 ) -> Result<ForgeEntry> {
-    let files = get_single_forge_files_manifest(&local_storage, long_version).await?;
+    let files = get_single_forge_files_manifest(local_storage, long_version).await?;
 
     let is_recommended = recommended_set.contains(version);
 
@@ -958,7 +958,7 @@ async fn get_single_forge_files_manifest(
     local_storage: &ForgeDataStorage,
     long_version: &str,
 ) -> Result<BTreeMap<String, ForgeFile>> {
-    let files_manifest = local_storage.load_files_manifest(&long_version)?;
+    let files_manifest = local_storage.load_files_manifest(long_version)?;
     let files_metadata = if let Some(files_manifest) = files_manifest {
         info!("Forge manifest for {long_version} stored localy");
         files_manifest
@@ -972,7 +972,7 @@ async fn get_single_forge_files_manifest(
         let remote_manifest = download::forge::load_single_forge_files_manifest(&file_url)
             .await
             .with_context(|| format!("Failure downloading {}", &file_url))?;
-        local_storage.store_files_manifest(&long_version, &remote_manifest)?;
+        local_storage.store_files_manifest(long_version, &remote_manifest)?;
         remote_manifest
     };
 

--- a/mcmeta/src/storage/mod.rs
+++ b/mcmeta/src/storage/mod.rs
@@ -8,7 +8,7 @@ mod forge;
 mod mojang;
 
 impl StorageFormat {
-    pub async fn initialize_metadata(&self, metadata_cfg: &MetadataConfig) -> Result<()> {
+    pub async fn update_upstream_metadata(&self, metadata_cfg: &MetadataConfig) -> Result<()> {
         let updater = UpstreamMetadataUpdater {
             storage_format: Arc::new(self.clone()),
             metadata_cfg: Arc::new(metadata_cfg.clone()),
@@ -30,8 +30,8 @@ impl StorageFormat {
             StorageFormat::Database => todo!(),
         }
 
-        updater.initialize_mojang_metadata().await?;
-        updater.initialize_forge_metadata().await?;
+        updater.update_mojang_metadata().await?;
+        updater.update_forge_metadata().await?;
 
         Ok(())
     }

--- a/mcmeta/src/storage/mod.rs
+++ b/mcmeta/src/storage/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{app_config::MetadataConfig, app_config::StorageFormat};
 use anyhow::Result;
 use tracing::info;
@@ -7,6 +9,10 @@ mod mojang;
 
 impl StorageFormat {
     pub async fn initialize_metadata(&self, metadata_cfg: &MetadataConfig) -> Result<()> {
+        let updater = UpstreamMetadataUpdater {
+            storage_format: Arc::new(self.clone()),
+            metadata_cfg: Arc::new(metadata_cfg.clone()),
+        };
         match self {
             StorageFormat::Json {
                 meta_directory,
@@ -21,7 +27,8 @@ impl StorageFormat {
                     std::fs::create_dir_all(metadata_dir)?;
                 }
 
-                mojang::initialize_mojang_metadata(self, metadata_cfg).await?;
+                updater.initialize_mojang_metadata().await?;
+
                 forge::initialize_forge_metadata(self, metadata_cfg).await?;
             }
             StorageFormat::Database => todo!(),
@@ -29,4 +36,10 @@ impl StorageFormat {
 
         Ok(())
     }
+}
+
+#[derive(Clone)]
+pub struct UpstreamMetadataUpdater {
+    storage_format: Arc<StorageFormat>,
+    metadata_cfg: Arc<MetadataConfig>,
 }

--- a/mcmeta/src/storage/mod.rs
+++ b/mcmeta/src/storage/mod.rs
@@ -26,13 +26,12 @@ impl StorageFormat {
                     );
                     std::fs::create_dir_all(metadata_dir)?;
                 }
-
-                updater.initialize_mojang_metadata().await?;
-
-                forge::initialize_forge_metadata(self, metadata_cfg).await?;
             }
             StorageFormat::Database => todo!(),
         }
+
+        updater.initialize_mojang_metadata().await?;
+        updater.initialize_forge_metadata().await?;
 
         Ok(())
     }

--- a/mcmeta/src/storage/mojang.rs
+++ b/mcmeta/src/storage/mojang.rs
@@ -1,204 +1,233 @@
-use std::path::Path;
+use std::sync::Arc;
 
 use futures::{stream, StreamExt};
 use libmcmeta::models::mojang::{
-    ExperimentEntry, ExperimentIndex, MojangVersionManifest, MojangVersionManifestVersion,
-    OldSnapshotEntry, OldSnapshotIndex, VersionDownload, VersionDownloads,
+    ExperimentEntry, ExperimentIndex, MinecraftVersion, MojangVersionManifest,
+    MojangVersionManifestVersion, OldSnapshotEntry, OldSnapshotIndex, VersionDownload,
+    VersionDownloads,
 };
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 use anyhow::{anyhow, Context, Result};
 
-use crate::{app_config::MetadataConfig, download, storage::StorageFormat};
+use crate::{
+    download,
+    storage::{StorageFormat, UpstreamMetadataUpdater},
+    utils::process_results,
+};
 
-fn process_results<T>(results: Vec<Result<T>>) -> Result<Vec<T>> {
-    let mut err_flag = false;
-    let mut ok_results = vec![];
-    for res in results {
-        if let Ok(ok_res) = res {
-            ok_results.push(ok_res);
-        } else {
-            error!("{}", res.err().unwrap());
-            err_flag = true;
-        }
-    }
-    if err_flag {
-        Err(anyhow!("There were errors in the results"))
-    } else {
-        Ok(ok_results)
-    }
+#[derive(Clone)]
+struct MojangDataStorage {
+    storage_format: Arc<StorageFormat>,
 }
 
-pub async fn initialize_mojang_metadata(
-    storage_format: &StorageFormat,
-    metadata_cfg: &MetadataConfig,
-) -> Result<()> {
-    info!("Checking for Mojang metadata");
-    match storage_format {
-        StorageFormat::Json {
-            meta_directory,
-            generated_directory: _,
-        } => {
-            let metadata_dir = std::path::Path::new(meta_directory);
-            let mojang_meta_dir = metadata_dir.join("mojang");
+impl MojangDataStorage {
+    pub fn meta_dir(&self) -> Result<std::path::PathBuf> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                ref meta_directory,
+                generated_directory: _,
+            } => {
+                let metadata_dir = std::path::Path::new(&meta_directory);
+                let mojang_meta_dir = metadata_dir.join("mojang");
 
-            if !mojang_meta_dir.exists() {
-                info!(
-                    "Mojang metadata directory at {} does not exist, creating it",
-                    mojang_meta_dir.display()
-                );
-                std::fs::create_dir_all(&mojang_meta_dir)?;
+                if !mojang_meta_dir.exists() {
+                    info!(
+                        "Mojang metadata directory at {} does not exist, creating it",
+                        mojang_meta_dir.display()
+                    );
+                    std::fs::create_dir_all(&mojang_meta_dir)?;
+                }
+                Ok(mojang_meta_dir)
             }
-
-            update_mojang_metadata_json(metadata_cfg, &mojang_meta_dir)
-                .await
-                .with_context(|| "Failed to update Mojang metadata in the json storage format")?;
-            update_mojang_static_metadata_json(metadata_cfg, &mojang_meta_dir)
-                .await
-                .with_context(|| {
-                    "Failed to update Mojang static metadata in the json storage format."
-                })
+            StorageFormat::Database => Err(anyhow!("Wrong storage format")),
         }
-        StorageFormat::Database => todo!(),
+    }
+
+    pub fn versions_dir(&self) -> Result<std::path::PathBuf> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let mojang_meta_dir = self.meta_dir()?;
+                let versions_dir = mojang_meta_dir.join("versions");
+                if !versions_dir.exists() {
+                    let versions_dir = mojang_meta_dir.join("versions");
+                    info!(
+                        "Mojang versions directory at {} does not exist, creating it",
+                        versions_dir.display()
+                    );
+                    std::fs::create_dir_all(&versions_dir)?;
+                }
+                Ok(versions_dir)
+            }
+            StorageFormat::Database => Err(anyhow!("Wrong storage format")),
+        }
+    }
+
+    pub fn load_manifest(&self) -> Result<Option<MojangVersionManifest>> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let local_manifest_path = self.meta_dir()?.join("version_manifest_v2.json");
+                if local_manifest_path.is_file() {
+                    let local_manifest = serde_json::from_str::<MojangVersionManifest>(
+                        &std::fs::read_to_string(&local_manifest_path)?,
+                    )?;
+                    Ok(Some(local_manifest))
+                } else {
+                    Ok(None)
+                }
+            }
+            StorageFormat::Database => todo!(),
+        }
+    }
+
+    pub fn store_manifest(&self, manifest: &MojangVersionManifest) -> Result<()> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let local_manifest_path = self.meta_dir()?.join("version_manifest_v2.json");
+                let manifest_json = serde_json::to_string_pretty(&manifest)?;
+                std::fs::write(&local_manifest_path, manifest_json)?;
+                Ok(())
+            }
+            StorageFormat::Database => todo!(),
+        }
+    }
+
+    pub fn load_minecraft_version(&self, id: &str) -> Result<Option<MinecraftVersion>> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let version_file = self.versions_dir()?.join(format!("{}.json", id));
+                if version_file.is_file() {
+                    let version = serde_json::from_str::<MinecraftVersion>(
+                        &std::fs::read_to_string(&version_file)?,
+                    )?;
+                    Ok(Some(version))
+                } else {
+                    Ok(None)
+                }
+            }
+            StorageFormat::Database => todo!(),
+        }
+    }
+
+    pub fn store_minecraft_version(&self, version: &MinecraftVersion) -> Result<()> {
+        match *self.storage_format {
+            StorageFormat::Json {
+                meta_directory: _,
+                generated_directory: _,
+            } => {
+                let version_file = self.versions_dir()?.join(format!("{}.json", version.id));
+                let version_manifest_json = serde_json::to_string_pretty(&version)?;
+                std::fs::write(&version_file, version_manifest_json)?;
+            }
+            StorageFormat::Database => todo!(),
+        }
+        Ok(())
     }
 }
 
-async fn update_mojang_metadata_json(
-    metadata_cfg: &MetadataConfig,
-    mojang_meta_dir: &Path,
-) -> Result<()> {
-    use std::collections::{HashMap, HashSet};
+impl UpstreamMetadataUpdater {
+    pub async fn initialize_mojang_metadata(&self) -> Result<()> {
+        info!("Checking for Mojang metadata");
 
-    info!("Acquiring remote Mojang metadata");
-    let remote_manifest = download::mojang::load_manifest().await?;
-    let remote_versions: HashMap<String, MojangVersionManifestVersion> = HashMap::from_iter(
-        remote_manifest
-            .versions
-            .iter()
-            .map(|v| (v.id.clone(), v.clone())),
-    );
-    let remote_ids =
-        HashSet::<String>::from_iter(remote_manifest.versions.iter().map(|v| v.id.clone()));
+        self.update_mojang_metadata()
+            .await
+            .with_context(|| "Failed to update Mojang metadata.")?;
+        self.update_mojang_static_metadata()
+            .await
+            .with_context(|| "Failed to update Mojang static metadata.")?;
+        Ok(())
+    }
 
-    let local_manifest_path = mojang_meta_dir.join("version_manifest_v2.json");
-    let pending_ids: Vec<(String, bool)> = if !local_manifest_path.is_file() {
-        info!("Local Mojang metadata does not exist, saving it");
-        let manifest_json = serde_json::to_string_pretty(&remote_manifest)?;
-        std::fs::write(&local_manifest_path, manifest_json)?;
+    pub async fn update_mojang_metadata(&self) -> Result<()> {
+        use std::collections::{HashMap, HashSet};
 
-        remote_ids.into_iter().map(|id| (id, true)).collect()
-    } else {
-        let local_manifest = serde_json::from_str::<MojangVersionManifest>(
-            &std::fs::read_to_string(&local_manifest_path)?,
-        )?;
-        let local_versions: HashMap<String, MojangVersionManifestVersion> = HashMap::from_iter(
-            local_manifest
+        let local_storage = MojangDataStorage {
+            storage_format: self.storage_format.clone(),
+        };
+        info!("Acquiring remote Mojang metadata");
+        let remote_manifest = download::mojang::load_manifest().await?;
+        let remote_versions: HashMap<String, MojangVersionManifestVersion> = HashMap::from_iter(
+            remote_manifest
                 .versions
                 .iter()
                 .map(|v| (v.id.clone(), v.clone())),
         );
-        let local_ids =
-            HashSet::<String>::from_iter(local_manifest.versions.iter().map(|v| v.id.clone()));
+        let remote_ids =
+            HashSet::<String>::from_iter(remote_manifest.versions.iter().map(|v| v.id.clone()));
 
-        let mut diff: Vec<(String, bool)> = remote_ids
-            .difference(&local_ids)
-            .cloned()
-            .map(|id| (id, false))
-            .collect();
-        let mut out_of_date: Vec<(String, bool)> = local_ids
-            .iter()
-            .filter_map(|id| {
-                let remote_version = remote_versions
-                    .get(id)
-                    .expect("local version to exist remotely");
-                let local_version = local_versions
-                    .get(id)
-                    .expect("local version to exist localy");
-                if remote_version.time > local_version.time {
-                    Some(id)
-                } else {
-                    None
-                }
-            })
-            .cloned()
-            .map(|id| (id, true))
-            .collect();
-        diff.append(&mut out_of_date);
-        diff
-    };
+        let local_manifest = local_storage.load_manifest()?;
+        let pending_ids: Vec<(String, bool)> = if let Some(local_manifest) = local_manifest {
+            let local_versions: HashMap<String, MojangVersionManifestVersion> = HashMap::from_iter(
+                local_manifest
+                    .versions
+                    .iter()
+                    .map(|v| (v.id.clone(), v.clone())),
+            );
+            let local_ids =
+                HashSet::<String>::from_iter(local_manifest.versions.iter().map(|v| v.id.clone()));
 
-    let versions_dir = mojang_meta_dir.join("versions");
-    if !versions_dir.exists() {
-        let versions_dir = mojang_meta_dir.join("versions");
-        info!(
-            "Mojang versions directory at {} does not exist, creating it",
-            versions_dir.display()
-        );
-        std::fs::create_dir_all(&versions_dir)?;
-    }
+            let mut diff: Vec<(String, bool)> = remote_ids
+                .difference(&local_ids)
+                .cloned()
+                .map(|id| (id, false))
+                .collect();
+            let mut out_of_date: Vec<(String, bool)> = local_ids
+                .iter()
+                .filter_map(|id| {
+                    let remote_version = if let Some(rv) = remote_versions.get(id) {
+                        rv
+                    } else {
+                        warn!("Mojang version {} does not exist remotely", id);
+                        return None;
+                    };
 
-    let tasks = stream::iter(pending_ids)
-        .map(|(version, force_update)| {
-            let v = remote_versions.get(&version).unwrap().clone();
-            let dir = versions_dir.clone();
-            tokio::spawn(async move {
-                update_mojang_version_manifest_json(&dir, &v, force_update)
-                    .await
-                    .with_context(|| format!("Failed to initialize Mojang version {}", v.id))
-            })
-        })
-        .buffer_unordered(metadata_cfg.max_parallel_fetch_connections);
-    let results = tasks
-        .map(|t| match t {
-            Ok(Ok(t)) => Ok(t),
-            Ok(Err(e)) => {
-                debug!("Task had an error: {:?}", e);
-                Err(e)
-            }
-            Err(e) => {
-                debug!("Task had a Join error: {:?}", e);
-                Err(e.into())
-            }
-        })
-        .collect::<Vec<_>>()
-        .await;
-    process_results(results)?;
-    Ok(())
-}
+                    let local_version = local_versions
+                        .get(id)
+                        .expect("local version to exist locally");
+                    if remote_version.time > local_version.time {
+                        Some(id)
+                    } else {
+                        None
+                    }
+                })
+                .cloned()
+                .map(|id| (id, true))
+                .collect();
+            diff.append(&mut out_of_date);
+            diff
+        } else {
+            info!("Local Mojang metadata does not exist, saving it");
+            local_storage.store_manifest(&remote_manifest)?;
 
-async fn update_mojang_static_metadata_json(
-    metadata_cfg: &MetadataConfig,
-    mojang_meta_dir: &Path,
-) -> Result<()> {
-    let static_dir = std::path::Path::new(&metadata_cfg.static_directory);
-    let versions_dir = mojang_meta_dir.join("versions");
-    if !versions_dir.exists() {
-        let versions_dir = mojang_meta_dir.join("versions");
-        info!(
-            "Mojang versions directory at {} does not exist, creating it",
-            versions_dir.display()
-        );
-        std::fs::create_dir_all(&versions_dir)?;
-    }
+            remote_ids.into_iter().map(|id| (id, true)).collect()
+        };
 
-    let static_experiments_path = static_dir.join("mojang").join("minecraft-experiments.json");
-    if static_experiments_path.is_file() {
-        let experiments = serde_json::from_str::<ExperimentIndex>(&std::fs::read_to_string(
-            &static_experiments_path,
-        )?)?;
-
-        let tasks = stream::iter(experiments.experiments)
-            .map(|experiment| {
-                let e = experiment;
-                let dir = versions_dir.clone();
-
+        let tasks = stream::iter(pending_ids)
+            .map(|(version, force_update)| {
+                let ls = local_storage.clone();
+                let v = remote_versions
+                    .get(&version)
+                    .expect("version to exist remotely")
+                    .clone();
                 tokio::spawn(async move {
-                    update_mojang_experiment_json(&dir, &e)
+                    update_mojang_version_manifest(&ls, &v, force_update)
                         .await
-                        .with_context(|| format!("Failed to initialize Mojang experiment {}", e.id))
+                        .with_context(|| format!("Failed to initialize Mojang version {}", v.id))
                 })
             })
-            .buffer_unordered(metadata_cfg.max_parallel_fetch_connections);
+            .buffer_unordered(self.metadata_cfg.max_parallel_fetch_connections);
         let results = tasks
             .map(|t| match t {
                 Ok(Ok(t)) => Ok(t),
@@ -214,55 +243,99 @@ async fn update_mojang_static_metadata_json(
             .collect::<Vec<_>>()
             .await;
         process_results(results)?;
+        Ok(())
     }
 
-    let static_old_snapshots_path = static_dir
-        .join("mojang")
-        .join("minecraft-old-snapshots.json");
-    if static_old_snapshots_path.is_file() {
-        let old_snapshots = serde_json::from_str::<OldSnapshotIndex>(&std::fs::read_to_string(
-            &static_old_snapshots_path,
-        )?)?;
+    async fn update_mojang_static_metadata(&self) -> Result<()> {
+        let local_storage = MojangDataStorage {
+            storage_format: self.storage_format.clone(),
+        };
 
-        let tasks = stream::iter(old_snapshots.old_snapshots)
-            .map(|snapshot| {
-                let s = snapshot;
-                let dir = versions_dir.clone();
+        let static_dir = std::path::Path::new(&self.metadata_cfg.static_directory);
 
-                tokio::spawn(async move {
-                    update_mojang_old_snapshot_json(&dir, &s)
-                        .await
-                        .with_context(|| format!("Failed to initialize Mojang experiment {}", s.id))
+        let static_experiments_path = static_dir.join("mojang").join("minecraft-experiments.json");
+        if static_experiments_path.is_file() {
+            let experiments = serde_json::from_str::<ExperimentIndex>(&std::fs::read_to_string(
+                &static_experiments_path,
+            )?)?;
+
+            let tasks = stream::iter(experiments.experiments)
+                .map(|experiment| {
+                    let ls = local_storage.clone();
+                    let e = experiment;
+
+                    tokio::spawn(async move {
+                        update_mojang_experiment(&ls, &e).await.with_context(|| {
+                            format!("Failed to initialize Mojang experiment {}", e.id)
+                        })
+                    })
                 })
-            })
-            .buffer_unordered(metadata_cfg.max_parallel_fetch_connections);
-        let results = tasks
-            .map(|t| match t {
-                Ok(Ok(t)) => Ok(t),
-                Ok(Err(e)) => {
-                    debug!("Task had an error: {:?}", e);
-                    Err(e)
-                }
-                Err(e) => {
-                    debug!("Task had a Join error: {:?}", e);
-                    Err(e.into())
-                }
-            })
-            .collect::<Vec<_>>()
-            .await;
-        process_results(results)?;
-    }
+                .buffer_unordered(self.metadata_cfg.max_parallel_fetch_connections);
+            let results = tasks
+                .map(|t| match t {
+                    Ok(Ok(t)) => Ok(t),
+                    Ok(Err(e)) => {
+                        debug!("Task had an error: {:?}", e);
+                        Err(e)
+                    }
+                    Err(e) => {
+                        debug!("Task had a Join error: {:?}", e);
+                        Err(e.into())
+                    }
+                })
+                .collect::<Vec<_>>()
+                .await;
+            process_results(results)?;
+        }
 
-    Ok(())
+        let static_old_snapshots_path = static_dir
+            .join("mojang")
+            .join("minecraft-old-snapshots.json");
+        if static_old_snapshots_path.is_file() {
+            let old_snapshots = serde_json::from_str::<OldSnapshotIndex>(
+                &std::fs::read_to_string(&static_old_snapshots_path)?,
+            )?;
+
+            let tasks = stream::iter(old_snapshots.old_snapshots)
+                .map(|snapshot| {
+                    let ls = local_storage.clone();
+                    let s = snapshot;
+
+                    tokio::spawn(async move {
+                        update_mojang_old_snapshot(&ls, &s).await.with_context(|| {
+                            format!("Failed to initialize Mojang experiment {}", s.id)
+                        })
+                    })
+                })
+                .buffer_unordered(self.metadata_cfg.max_parallel_fetch_connections);
+            let results = tasks
+                .map(|t| match t {
+                    Ok(Ok(t)) => Ok(t),
+                    Ok(Err(e)) => {
+                        debug!("Task had an error: {:?}", e);
+                        Err(e)
+                    }
+                    Err(e) => {
+                        debug!("Task had a Join error: {:?}", e);
+                        Err(e.into())
+                    }
+                })
+                .collect::<Vec<_>>()
+                .await;
+            process_results(results)?;
+        }
+
+        Ok(())
+    }
 }
 
-pub async fn update_mojang_version_manifest_json(
-    versions_dir: &std::path::Path,
+async fn update_mojang_version_manifest(
+    local_storage: &MojangDataStorage,
     version: &MojangVersionManifestVersion,
     force_update: bool,
 ) -> Result<()> {
-    let version_file = versions_dir.join(format!("{}.json", &version.id));
-    if !version_file.is_file() || force_update {
+    let local_manifest = local_storage.load_minecraft_version(&version.id)?;
+    if local_manifest.is_none() || force_update {
         info!(
             "Updating Mojang metadata for version {} to timestamp {}",
             &version.id, &version.time
@@ -277,18 +350,17 @@ pub async fn update_mojang_version_manifest_json(
                 );
                 err
             })?;
-        let version_manifest_json = serde_json::to_string_pretty(&version_manifest)?;
-        std::fs::write(&version_file, version_manifest_json)?;
+        local_storage.store_minecraft_version(&version_manifest)?;
     }
     Ok(())
 }
 
-pub async fn update_mojang_experiment_json(
-    versions_dir: &std::path::Path,
+async fn update_mojang_experiment(
+    local_storage: &MojangDataStorage,
     version: &ExperimentEntry,
 ) -> Result<()> {
-    let version_file = versions_dir.join(format!("{}.json", &version.id));
-    if !version_file.is_file() {
+    let local_version = local_storage.load_minecraft_version(&version.id)?;
+    if local_version.is_none() {
         info!(
             "Mojang metadata for experiment {} does not exist, downloading it",
             &version.id
@@ -303,18 +375,17 @@ pub async fn update_mojang_experiment_json(
                 );
                 err
             })?;
-        let version_manifest_json = serde_json::to_string_pretty(&version_manifest)?;
-        std::fs::write(&version_file, version_manifest_json)?;
+        local_storage.store_minecraft_version(&version_manifest)?;
     }
     Ok(())
 }
 
-pub async fn update_mojang_old_snapshot_json(
-    versions_dir: &std::path::Path,
+async fn update_mojang_old_snapshot(
+    local_storage: &MojangDataStorage,
     snapshot: &OldSnapshotEntry,
 ) -> Result<()> {
-    let version_file = versions_dir.join(format!("{}.json", &snapshot.id));
-    if !version_file.is_file() {
+    let local_version = local_storage.load_minecraft_version(&snapshot.id)?;
+    if local_version.is_none() {
         info!(
             "Mojang metadata for old snapshot {} does not exist, downloading it",
             &snapshot.id
@@ -348,8 +419,7 @@ pub async fn update_mojang_old_snapshot_json(
 
         version_manifest.release_type = "old_snapshot".to_string();
 
-        let version_manifest_json = serde_json::to_string_pretty(&version_manifest)?;
-        std::fs::write(&version_file, version_manifest_json)?;
+        local_storage.store_minecraft_version(&version_manifest)?;
     }
     Ok(())
 }

--- a/mcmeta/src/storage/mojang.rs
+++ b/mcmeta/src/storage/mojang.rs
@@ -222,8 +222,7 @@ impl UpstreamMetadataUpdater {
             diff.append(&mut out_of_date);
             diff
         } else {
-            info!("Local Mojang metadata does not exist, saving it");
-            local_storage.store_manifest(&remote_manifest)?;
+            info!("Local Mojang metadata does not exist, fetching all versions");
 
             remote_ids.into_iter().map(|id| (id, true)).collect()
         };
@@ -257,6 +256,9 @@ impl UpstreamMetadataUpdater {
             .collect::<Vec<_>>()
             .await;
         process_results(results)?;
+
+        // update the locally stored manifest
+        local_storage.store_manifest(&remote_manifest)?;
         Ok(())
     }
 

--- a/mcmeta/src/storage/mojang.rs
+++ b/mcmeta/src/storage/mojang.rs
@@ -211,14 +211,12 @@ impl UpstreamMetadataUpdater {
                         .get(id)
                         .expect("local version to exist locally");
                     if remote_version.time > local_version.time {
-                        Some(id)
+                        Some((id.clone(), true))
                     } else {
                         None
                     }
                 })
-                .cloned()
-                .map(|id| (id, true))
-                .collect();
+                .collect::<Vec<_>>();
             diff.append(&mut out_of_date);
             diff
         } else {

--- a/mcmeta/src/storage/mojang.rs
+++ b/mcmeta/src/storage/mojang.rs
@@ -152,7 +152,7 @@ impl MojangDataStorage {
 }
 
 impl UpstreamMetadataUpdater {
-    pub async fn initialize_mojang_metadata(&self) -> Result<()> {
+    pub async fn update_upstream_mojang(&self) -> Result<()> {
         info!("Checking for Mojang metadata");
 
         self.update_mojang_metadata()
@@ -262,7 +262,7 @@ impl UpstreamMetadataUpdater {
         Ok(())
     }
 
-    async fn update_mojang_static_metadata(&self) -> Result<()> {
+    pub async fn update_mojang_static_metadata(&self) -> Result<()> {
         let local_storage = MojangDataStorage {
             storage_format: self.storage_format.clone(),
         };

--- a/mcmeta/src/utils.rs
+++ b/mcmeta/src/utils.rs
@@ -199,6 +199,27 @@ pub fn filehash(path: &std::path::PathBuf, algo: HashAlgo) -> Result<String> {
     }
 }
 
+pub fn hash(data: impl AsRef<[u8]>, algo: HashAlgo) -> Result<String> {
+    match algo {
+        HashAlgo::Sha1 => {
+            use sha1::{Digest, Sha1};
+
+            let mut hasher = Sha1::new();
+            hasher.update(data);
+            let hash_bytes = hasher.finalize();
+            Ok(format!("{:X}", hash_bytes))
+        }
+        HashAlgo::Sha256 => {
+            use sha2::{Digest, Sha256};
+
+            let mut hasher = Sha256::new();
+            hasher.update(data);
+            let hash_bytes = hasher.finalize();
+            Ok(format!("{:X}", hash_bytes))
+        }
+    }
+}
+
 /**
 * Process a `Vec<Result<T>>` int a `Result<Vec<T>>` concatenating any error messages encountered
 */
@@ -220,4 +241,11 @@ pub fn process_results<T>(results: Vec<Result<T>>) -> Result<Vec<T>> {
     } else {
         Ok(ok_results)
     }
+}
+
+pub fn process_results_ok<T>(results: Vec<Result<T>>) -> Vec<T> {
+    results
+        .into_iter()
+        .filter_map(|res: Result<T>| res.ok())
+        .collect()
 }


### PR DESCRIPTION
This PR splits off the data storage currently used to their own struct impls. `load` and `store` functions control where data is loaded from and written to so that the code can be mostly agnostic as to if it is being stored in json format.